### PR TITLE
only score the top 6 races

### DIFF
--- a/orchestrate/s2425/__main__.py
+++ b/orchestrate/s2425/__main__.py
@@ -17,7 +17,7 @@ def compute_all_individual_points(g: Gender):
 
 def compute_and_write_all_individual_points(g: Gender):
     aip = compute_all_individual_points(g) \
-        .sort(['total_points', 'first_name', 'last_name'], descending=True) # name just adds a stable sort for ties
+        .sort(['final_points', 'first_name', 'last_name'], descending=True) # name just adds a stable sort for ties
 
     for rc in ['skadischase_points', 'hiihto_points', 'firstchance_points', 'll_challenge_points', 'mount_ashwabay_points',
                'coll_points']:
@@ -30,6 +30,7 @@ def compute_and_write_all_individual_points(g: Gender):
         pl.concat_str(['first_name', 'last_name'], separator=' ').alias('Name'),
         pl.Series(name='Overall Place', values=range(1, aip.shape[0] + 1)),
         pl.col('total_points').round(2).alias('total_points'),
+        pl.col('final_points').round(2).alias('final_points')
     ) \
         .rename({
         'skadischase_points': "Skadi's Chase Points",
@@ -40,6 +41,7 @@ def compute_and_write_all_individual_points(g: Gender):
         'coll_points': 'City of Lakes Loppet Points',
         'total_points': 'Total Points',
         'n_events': 'Number of Events',
+        'final_points': 'Final Points',
     }) \
         .select('Name', 'Overall Place', 'Number of Events',
                 "Skadi's Chase Points", 'Hiihto Relay Points',

--- a/score/__init__.py
+++ b/score/__init__.py
@@ -1,4 +1,5 @@
 import polars as pl
+import heapq
 
 # TODO this is awkward, have to update the definition each season
 from orchestrate.s2425 import Event
@@ -96,28 +97,37 @@ def compute_total_individual_points(
 
     total_event_points = []
     total_n_events = []
+    series_event_points = []
     for ar in aggregate_results.iter_rows(named=True):
         n_events = 0
         all_event_points = 0
+        ind_event_points = []
         for e in events:
             event_points = ar[f'{e.to_string()}_points']
             # TODO
             if event_points is not None:
                 n_events += 1
                 all_event_points += event_points
+                ind_event_points.append(event_points)
 
         total_event_points.append(all_event_points)
         total_n_events.append(n_events)
+        # limit points to the top 6 results for an individual
+        series_event_points.append(sum(heapq.nlargest(6,ind_event_points)))
 
     aggregate_results = aggregate_results\
         .with_columns(
             pl.Series(name='total_event_points', values=total_event_points),
-            pl.Series(name='n_events', values=total_n_events)
+            pl.Series(name='n_events', values=total_n_events),
+            pl.Series(name='series_points', values=series_event_points)
         )
 
     ar_with_ei = attach_event_incentives(aggregate_results)
     ar_with_ei = ar_with_ei.with_columns(
         pl.col('total_event_points').add(pl.col('event_incentive_points')).alias('total_points')
+    )
+    ar_with_ei = ar_with_ei.with_columns(
+        pl.col('series_points').add(pl.col('event_incentive_points')).alias('final_points')
     )
     return ar_with_ei
 


### PR DESCRIPTION
Yay for more races!  The rules on the website are a little ambiguous.  It says top 6 results, but then talks about dropping 3 races of 9 (but there are 13 in the series this year).

In any case, there are some skiers who are up to 7 races now after this past weekend so if the limit really is 6, I think this is missing from the code.

It might not be exactly what what you want to do.  Please test with vasaloppet results before accepting.  I think this is likely to start shaking things up at the top of the results.