### PR TITLE
Team Membership

### DIFF
--- a/db/s2425/.gitignore
+++ b/db/s2425/.gitignore
@@ -1,1 +1,0 @@
-Team Registration.xlsx

--- a/db/s2425/__init__.py
+++ b/db/s2425/__init__.py
@@ -50,8 +50,7 @@ def _expand_team_row(r):
 
 
 def load_team_membership() -> pl.DataFrame:
-    # note, this data is not published to VC to protect personal data (birthday/emails)
-    raw = pl.read_excel(f'db/s2425/Team Registration.xlsx', sheet_name='2024-2025 Long')
+    raw = pl.read_csv(f'db/s2425/teams.csv')
     if not raw.n_unique(subset=TEAM_NAME_COL) == raw.shape[0]:
         raise ValueError('Expected team name to be unique, crashing out to avoid downstream problems')
 

--- a/db/s2425/teams.csv
+++ b/db/s2425/teams.csv
@@ -1,0 +1,12 @@
+Team Name:,Team captain/representative name:,Team captain gender,2nd team member name,2nd team member gender,3rd team member name,3rd team member gender,4th team member name,4th team member gender,5th team member name,5th team member gender,6th team member name,6th team member gender,7th team member name,7th team member gender,8th team member name,8th team member gender,9th team member name,9th team member gender,10th team member name,10th team member gender
+Finnish Postal Service,Karl Holub,Male,Tyler Gilbert,Male,Nathan Rhode,Male,Rebecca Kolstad,Female,Spencer Davis,Male,Molly Watkins,Female,Peter Thor,Male,,,,,,
+Flying Fungi of Yuggoth,Allie Rykken,female,Siri Stolen,female,Kira Stolen,Female,Katie Schaaf,Female,Emily Broderson,Female,Kevin Johnson,Male,Devin Arenz,Male,Brett Arenz,male,Fred Kueffer,male,Craig Stolen,male
+Team Birkie,Jake Stiele,Male,Jenna Nelson,Female,Maxwell Turnberg,Male,Vivian Johnson,Female,Zach Nelson,Male,Abby Drach,Female,Delaney Fitzpatrick,Female,Nicole Eliasson,Female,Sam Holt,Male,,
+TCSC Icy Insurgents,Mitchell Campbell,Male,Katrin O'Grady,Female,Gabriella Haire,Female,Julia Lavanger,Female,Ryan Rogers,Male,Julia Reich,Female,Nathan Orf,Male,Isaac Wieber,Male,Emmett Donohue,Male,Kathryn Pintar,Female
+YAM BAM Thank you Ma'am!,Julie Garretson,Female,Lisa Garretson,Female,Emily Fjorden,Female,Alissa Johnson,Female,Maggie Ludwig,Female,Louis Sirota,Male,Josh Doebbert,Male,Andrew Tilman,Male,Taylor Fay,Male,Erik Hendrickson,Male
+TCSC: Frosty Fliers,Chad Korby,Male,Ben Fuller,Male,Anna Meyer,Female,Micah Johnson,Male,Rob Rutscher,Male,Michael Garlinghouse,Male,Rachael Sawyer,Female,Danielle Ungurian,Female,Anna Klein,Female,,
+Vakava Pink,Laura Cattaneo,Female,Elspeth Ronnander,Female,Eva Reinicke,Female,Gabby Vandendries,Female,Elena Cattaneo,Female,Craig Cardinal,Male,Erik Pieh,Male,Ian Wright,Male,Ben Mullin,,Brock Lundberg,Male
+Vakava Blue,David Christopherson,Male,Hans Harlane,Male,Artie Huber,Male,Josh Albrecht,Male,Adrienne Keller,Female,Maria Schilling,Female,Katy Splan,Female,Mary Beth Tuttle,Female,Cheryl DuBois,Female,Christopher Jopp,Male
+Heikki Lunta,Alex Brault,Male,Quinn Schollett,Female,Darla Lenz,Female,Erin Brault,Female,Shannon Brault,Female,Riley Schollett,Male,,,,,,,,
+Hoigaard's Classic,Paul Schoening,Male,Victoria Ranua,Female,Jesse Longley,Male,Travis Hinck,Male,Erik Minge,Male,,,,,,,,,,
+Hoigaard's Skate,Steve Eberly,Male,John Horns,Male,John Rock,Male,Jason Sieg,Male,Rick Pike,Male,,,,,,,,,,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ nameparser==1.1.3
 polars==0.19.12
 pytimeparse==1.1.8
 requests==2.31.0
-xlsx2csv==0.8.4


### PR DESCRIPTION
## What
To assist in addressing #3. I took our existing team registration file (which included some sensitive personal data) and stripped it down to names (which is all we need for scoring).

## Testing
The before/after diff when generating team standings was empty.