### PR TITLE
Alias name check

### DIFF
--- a/db/known_aliases.csv
+++ b/db/known_aliases.csv
@@ -1,0 +1,8 @@
+alias_fn,alias_ln,actual_fn,actual_ln
+Benjamin,Mullin,Ben,Mullin
+Joshua,Doebbert,Josh,Doebbert
+Arthur,Huber,Artie,Huber
+Nicole,Schneider,Nicole,Eliasson
+Nathan,Rode,Nate,Rode
+Gabrielle,Vandendries,Gabby,Vandendries
+Mary,Beth Tuttle,Mary Beth,Tuttle

--- a/db/namequality.py
+++ b/db/namequality.py
@@ -1,0 +1,67 @@
+from tdfio.const import Gender
+import polars as pl
+
+class Ansi:
+    RESET = "\033[0m"
+    BOLD = "\033[1m"
+
+    RED = "\033[31m"
+    GREEN = "\033[32m"
+    YELLOW = "\033[33m"
+    BLUE = "\033[34m"
+    CYAN = "\033[36m"
+
+def perform_alias_quality_check(g: Gender, events: list, load_results: callable):
+    """Perform a quality check on alias names in the results.
+
+    Args:
+        g (Gender): The gender category to check.
+        events (list): The list of events to check.
+        load_results (callable): A function to load results for a given event and gender.
+    """
+    known_aliases = pl.read_csv("db/known_aliases.csv")
+
+    issues = []
+
+    for event in events:
+        df = load_results(event, g)
+        if df is None:
+            continue
+
+        hits = (
+            df.join(
+                known_aliases,
+                how="inner",
+                left_on=["first_name", "last_name"],
+                right_on=["alias_fn", "alias_ln"],
+            )
+            .with_columns(
+                pl.lit(event.to_string()).alias("event"),
+                pl.lit(g.to_string()).alias("gender"),
+            )
+            .select(
+                ["event", "gender", "first_name", "last_name", "actual_fn", "actual_ln"]
+                + ([c for c in ["gender_place", "age"] if c in df.columns])
+            )
+        )
+
+        if hits.height > 0:
+            issues.append(hits)
+
+    if not issues:
+        print(f"{g.to_string()}: Alias quality check: no known-alias matches found.")
+        return
+
+    report = pl.concat(issues).sort(["event", "gender", "last_name", "first_name"])
+
+    print(f"{Ansi.RED}Alias quality check: FOUND {report.height} possible match(es):{Ansi.RESET}")
+    for r in report.iter_rows(named=True):
+        place = f", place={r['gender_place']}" if "gender_place" in r else ""
+        age = f", age={r['age']}" if "age" in r else ""
+        print(
+            f"{Ansi.YELLOW}"
+            f"  - {r['event']} / {r['gender']}: "
+            f"{r['first_name']} {r['last_name']} matches alias → prefer {r['actual_fn']} {r['actual_ln']}"
+            f"{place}{age}"
+            f"{Ansi.RESET}"
+        )

--- a/db/namequality.py
+++ b/db/namequality.py
@@ -49,7 +49,6 @@ def perform_alias_quality_check(g: Gender, events: list, load_results: callable)
             issues.append(hits)
 
     if not issues:
-        print(f"{g.to_string()}: Alias quality check: no known-alias matches found.")
         return
 
     report = pl.concat(issues).sort(["event", "gender", "last_name", "first_name"])
@@ -65,3 +64,4 @@ def perform_alias_quality_check(g: Gender, events: list, load_results: callable)
             f"{place}{age}"
             f"{Ansi.RESET}"
         )
+        print("To make this alert go away, either consolidate the aliased names to the preferred names in db/season/*.csv or remove the alias from db/known_aliases.csv if it's a frequent false positive.")

--- a/orchestrate/s2425/__main__.py
+++ b/orchestrate/s2425/__main__.py
@@ -1,10 +1,9 @@
 import polars as pl
-from db.namequality import perform_alias_quality_check
 from db.s2425 import load_results, load_team_membership
+from db.namequality import perform_alias_quality_check
 from orchestrate.s2425 import Event
 from score import compute_total_individual_points, compute_team_points
 from tdfio.const import Gender
-from db.namequality import perform_alias_quality_check
 
 EVENTS_TO_SCORE = [Event.skadischase, Event.hiihto, Event.firstchance, Event.ll_challenge, Event.mount_ashwabay,
                    Event.coll, Event.vasaloppet, Event.pepsi_challenge, Event.snu]

--- a/orchestrate/s2425/__main__.py
+++ b/orchestrate/s2425/__main__.py
@@ -1,8 +1,10 @@
 import polars as pl
+from db.namequality import perform_alias_quality_check
 from db.s2425 import load_results, load_team_membership
 from orchestrate.s2425 import Event
 from score import compute_total_individual_points, compute_team_points
 from tdfio.const import Gender
+from db.namequality import perform_alias_quality_check
 
 EVENTS_TO_SCORE = [Event.skadischase, Event.hiihto, Event.firstchance, Event.ll_challenge, Event.mount_ashwabay,
                    Event.coll, Event.vasaloppet, Event.pepsi_challenge, Event.snu]
@@ -105,7 +107,9 @@ def compute_and_write_team_points():
 
 
 if __name__ == '__main__':
-    compute_and_write_all_individual_points(Gender.female)
-    compute_and_write_all_individual_points(Gender.male)
-    compute_and_write_all_individual_points(Gender.nb)
+    genders = [Gender.female, Gender.male, Gender.nb]
+
+    for g in genders:
+        perform_alias_quality_check(g, events=EVENTS_TO_SCORE, load_results=load_results)
+        compute_and_write_all_individual_points(g)
     compute_and_write_team_points()

--- a/orchestrate/s2526/__main__.py
+++ b/orchestrate/s2526/__main__.py
@@ -89,7 +89,5 @@ if __name__ == '__main__':
     # Perform and report on name quality
     for g in genders:
         perform_alias_quality_check(g, events=EVENTS_TO_SCORE, load_results=load_results)
-
-    for g in genders:
         compute_and_write_all_individual_points(g)
     compute_and_write_team_points()

--- a/orchestrate/s2526/__main__.py
+++ b/orchestrate/s2526/__main__.py
@@ -1,9 +1,9 @@
 import polars as pl
 from db.s2526 import load_results, load_team_membership
+from db.namequality import perform_alias_quality_check
 from orchestrate.s2526 import Event
 from score import compute_total_individual_points, compute_team_points
 from tdfio.const import Gender
-from db.namequality import perform_alias_quality_check
 
 EVENTS_TO_SCORE = [Event.bcfk, Event.seeley]
 

--- a/orchestrate/s2526/__main__.py
+++ b/orchestrate/s2526/__main__.py
@@ -3,6 +3,7 @@ from db.s2526 import load_results, load_team_membership
 from orchestrate.s2526 import Event
 from score import compute_total_individual_points, compute_team_points
 from tdfio.const import Gender
+from db.namequality import perform_alias_quality_check
 
 EVENTS_TO_SCORE = [Event.bcfk, Event.seeley]
 
@@ -77,10 +78,18 @@ def compute_and_write_team_points():
                 'Total Points')\
         .write_csv('orchestrate/s2526/tdf_team_standings.csv')
 
-
 if __name__ == '__main__':
-    compute_and_write_all_individual_points(Gender.female)
-    compute_and_write_all_individual_points(Gender.male)
-    # Reinstitute when there are results
-    # compute_and_write_all_individual_points(Gender.nb)
+    genders = [
+        Gender.female,
+        Gender.male,
+        # TODO Reinstitute when there are results
+        # Gender.nb
+    ]
+
+    # Perform and report on name quality
+    for g in genders:
+        perform_alias_quality_check(g, events=EVENTS_TO_SCORE, load_results=load_results)
+
+    for g in genders:
+        compute_and_write_all_individual_points(g)
     compute_and_write_team_points()


### PR DESCRIPTION
@holub008 here is the basic idea.  This is paired down to just checking for known issues.  As issues are identified they can get added to this list of aliases for future checking.

It still requires someone to notice a new issue for the first time, but at least after that there is a tickler for the person running orchestration to catch and fix the same issue in the future.

I skimmed back through the old commits to see what ones I could find and added them to this list.  I also added the recent maiden/married name correction in the event that those results end up attached to the wrong place.  I know my wife was never able to get her Ultra Sign-up account merged after her name change and figured something like that could be a possibility.

So now the shady characters who go by different names at different results may be less of a problem.

Future extensibility would be to track if it has been run and if any thing is a false positive to make it stop squawking about it every time you run.