### PR TITLE
Generate a scoring summary for team points review.

### DIFF
--- a/orchestrate/s2526/__init__.py
+++ b/orchestrate/s2526/__init__.py
@@ -5,11 +5,14 @@ from tdfio.const import Gender
 
 
 class Event(Enum):
-    bcfk = auto()
-    seeley = auto()
+    bcfk = "Battle Creek Fifty K"
+    seeley = "Seeley Hills Classic"
 
     def to_string(self) -> str:
         return self.name
+    
+    def get_human_readable_name(self) -> str:
+        return self.value
 
     @staticmethod
     def from_string(s: str):

--- a/orchestrate/s2526/__main__.py
+++ b/orchestrate/s2526/__main__.py
@@ -56,7 +56,7 @@ def compute_and_write_team_points():
     membership = load_team_membership()
     male_points = compute_all_individual_points(Gender.male)
     female_points = compute_all_individual_points(Gender.female)
-    tp = compute_team_points(membership, male_points, female_points, EVENTS_TO_SCORE)
+    (tp, report) = compute_team_points(membership, male_points, female_points, EVENTS_TO_SCORE)
     tp\
         .sort('total_points', descending=True)\
         .with_columns(
@@ -77,6 +77,10 @@ def compute_and_write_team_points():
                 'Total Points')\
         .write_csv('orchestrate/s2526/tdf_team_standings.csv')
 
+    report\
+        .sort(['team_name','event','gender','team_rank'],descending=[False,False,False,False])\
+        .select('team_name', 'event', 'gender', 'first_name', 'last_name', 'team_rank', 'event_points', 'is_scoring')\
+        .write_csv('orchestrate/s2526/tdf_team_scoring_report.csv')
 
 if __name__ == '__main__':
     compute_and_write_all_individual_points(Gender.female)

--- a/orchestrate/s2526/tdf_team_scoring_report.csv
+++ b/orchestrate/s2526/tdf_team_scoring_report.csv
@@ -1,79 +1,79 @@
 team_name,event,gender,first_name,last_name,team_rank,event_points,is_scoring
-Casual Elite,bcfk,male,Will,Nielsen,1,72.0,true
-Casual Elite,bcfk,male,Dave,Niday,2,69.0,true
-Casual Elite,seeley,male,Dave,Niday,1,20.0,true
-Des Moines Lake Nordic Ski Team,seeley,male,Brian,Markes,1,20.0,true
-Des Moines Lake Nordic Ski Team,seeley,male,Adam,Burnett,1,20.0,true
-Finnish Postal Service,bcfk,female,Rebecca,Kolstad,1,58.82352941176471,true
-Finnish Postal Service,bcfk,male,Spencer,Davis,1,90.0,true
-Finnish Postal Service,seeley,female,Molly,Watkins,1,20.0,true
-Finnish Postal Service,seeley,male,Karl,Holub,1,98.02631578947368,true
-Finnish Postal Service,seeley,male,Spencer,Davis,2,95.39473684210526,true
-Flying Fungi of Yuggoth,bcfk,female,Allie,Rykken,1,79.41176470588236,true
-Flying Fungi of Yuggoth,bcfk,male,Kevin,Johnson,1,68.0,true
-Flying Fungi of Yuggoth,bcfk,male,Brett,Arenz,2,57.00000000000001,true
-Flying Fungi of Yuggoth,bcfk,male,Devin,Arenz,3,38.0,true
-Flying Fungi of Yuggoth,seeley,female,Allie,Rykken,1,95.89041095890411,true
-Flying Fungi of Yuggoth,seeley,female,Emily,Broderson,2,63.273972602739725,true
-Flying Fungi of Yuggoth,seeley,male,Kevin,Johnson,1,95.73684210526316,true
-Hoigaards/Breadsmith A Team,bcfk,female,Michelle,Hatch,1,67.64705882352942,true
-Hoigaards/Breadsmith A Team,bcfk,female,Kaitsy,Baker,2,50.0,true
-Hoigaards/Breadsmith A Team,seeley,female,Victoria,Ranua,1,69.86301369863014,true
-Hoigaards/Breadsmith A Team,seeley,male,John,Rock,1,85.73684210526316,true
-Hoigaards/Breadsmith A Team,seeley,male,Paul,Schoening,2,78.15789473684211,true
-Hoigaards/Breadsmith A Team,seeley,male,Anders,Sonnesyn,3,20.0,true
-Hoigaards/Breadsmith A Team,seeley,male,Rick,Pike,3,20.0,true
-Ski EU Later,bcfk,female,Julie,Rieth,1,44.29411764705882,true
-Ski EU Later,bcfk,female,Sarah,Richter,2,41.17647058823529,true
-Ski EU Later,bcfk,female,Molly,Schaus,3,38.23529411764706,true
-Ski EU Later,bcfk,male,Ron,Omann,1,73.0,true
-Ski EU Later,bcfk,male,Ryan,Soule,2,71.0,true
-Ski EU Later,bcfk,male,Paul,Earl-Torniainen,3,50.0,true
-Ski EU Later,seeley,female,Julie,Rieth,1,82.97260273972603,true
-Ski EU Later,seeley,female,Patty,Carlen,2,20.0,true
-Ski EU Later,seeley,female,Molly,Schaus,2,20.0,true
-Ski EU Later,seeley,female,Sarah,Richter,2,20.0,true
-Ski EU Later,seeley,male,Ron,Omann,1,97.76315789473684,true
-Ski EU Later,seeley,male,Joseph,Altendahl,2,20.0,true
-Snowbra Kai Academy,bcfk,male,Dennis,Curran,1,84.0,true
-Snowbra Kai Academy,bcfk,male,Scott,Bjorn Cummings,2,29.000000000000004,true
-TCSC Frosty Fliers,bcfk,male,Joe,Harrington,1,93.0,true
-TCSC Frosty Fliers,bcfk,male,Steven,Deckert,2,31.999999999999996,true
-TCSC Icy Insurgents,bcfk,female,Katrin,O'Grady,1,97.05882352941177,true
-TCSC Icy Insurgents,bcfk,female,Julia,Reich,2,94.11764705882352,true
-TCSC Icy Insurgents,bcfk,female,Daisy,Richmond,3,47.05882352941176,true
-TCSC Icy Insurgents,bcfk,female,Kathryn,Pintar,4,20.0,false
-TCSC Icy Insurgents,bcfk,male,Ryan,Rogers,1,99.0,true
-TCSC Icy Insurgents,bcfk,male,Michael,Garlinghouse,2,62.0,true
-TCSC Icy Insurgents,seeley,female,Julia,Lavanger,1,93.15068493150685,true
-TCSC Icy Insurgents,seeley,female,Kathryn,Pintar,2,89.04109589041096,true
-TCSC Icy Insurgents,seeley,female,Daisy,Richmond,3,20.0,true
-TCSC Icy Insurgents,seeley,male,Chad,Korby,1,96.71052631578947,true
-Vakava Juniorit,bcfk,female,Laura,Cattaneo,1,91.17647058823529,true
-Vakava Juniorit,bcfk,male,Ian,Wright,1,89.0,true
-Vakava Juniorit,bcfk,male,Josh,Albrecht,2,85.0,true
-Vakava Juniorit,bcfk,male,McEwan,Rodefeld,3,25.0,true
-Vakava Juniorit,bcfk,male,Leif,Hanson,4,24.0,false
-Vakava Juniorit,seeley,female,Gabby,Vandendries,1,100.0,true
-Vakava Juniorit,seeley,male,Josh,Albrecht,1,99.3421052631579,true
-Vakava Juniorit,seeley,male,Leif,Hanson,2,98.68421052631578,true
-Vakava Seniorit,bcfk,female,Eva,Reinicke,1,61.76470588235294,true
-Vakava Seniorit,bcfk,female,Adrienne,Keller,2,52.94117647058824,true
-Vakava Seniorit,bcfk,male,Craig,Cardinal,1,96.0,true
-Vakava Seniorit,bcfk,male,Brock,Lundberg,2,69.0,true
-Vakava Seniorit,bcfk,male,Ben,Mullin,3,29.000000000000004,true
-Vakava Seniorit,seeley,female,Eva,Reinicke,1,75.34246575342466,true
-Vakava Seniorit,seeley,male,Artie,Huber,1,94.1578947368421,true
-Vakava Seniorit,seeley,male,Ben,Mullin,2,92.44736842105263,true
-Yamageddon,bcfk,female,Alissa,Johnson,1,55.88235294117647,true
-Yamageddon,bcfk,female,Daria,Terenteva,2,44.11764705882353,true
-Yamageddon,bcfk,female,Julie,Garretson,3,26.470588235294112,true
-Yamageddon,bcfk,male,Andrew,Tilman,1,95.0,true
-Yamageddon,bcfk,male,Louis,Sirota,2,82.0,true
-Yamageddon,bcfk,male,Josh,Doebbert,3,70.0,true
-Yamageddon,seeley,female,Julie,Garretson,1,94.52054794520548,true
-Yamageddon,seeley,female,Ana,Zembryki,2,67.12328767123287,true
-Yamageddon,seeley,male,Josh,Doebbert,1,88.81578947368422,true
-Yamageddon,seeley,male,Andrew,Tilman,2,20.0,true
-Yamageddon,seeley,male,Louis,Sirota,2,20.0,true
-Yamageddon,seeley,male,Erik,Hendrickson,2,20.0,true
+Casual Elite,Battle Creek Fifty K,male,Will,Nielsen,1,72.0,Yes
+Casual Elite,Battle Creek Fifty K,male,Dave,Niday,2,69.0,Yes
+Casual Elite,Seeley Hills Classic,male,Dave,Niday,1,20.0,Yes
+Des Moines Lake Nordic Ski Team,Seeley Hills Classic,male,Brian,Markes,1,20.0,Yes
+Des Moines Lake Nordic Ski Team,Seeley Hills Classic,male,Adam,Burnett,1,20.0,Yes
+Finnish Postal Service,Battle Creek Fifty K,female,Rebecca,Kolstad,1,58.82,Yes
+Finnish Postal Service,Battle Creek Fifty K,male,Spencer,Davis,1,90.0,Yes
+Finnish Postal Service,Seeley Hills Classic,female,Molly,Watkins,1,20.0,Yes
+Finnish Postal Service,Seeley Hills Classic,male,Karl,Holub,1,98.03,Yes
+Finnish Postal Service,Seeley Hills Classic,male,Spencer,Davis,2,95.39,Yes
+Flying Fungi of Yuggoth,Battle Creek Fifty K,female,Allie,Rykken,1,79.41,Yes
+Flying Fungi of Yuggoth,Battle Creek Fifty K,male,Kevin,Johnson,1,68.0,Yes
+Flying Fungi of Yuggoth,Battle Creek Fifty K,male,Brett,Arenz,2,57.0,Yes
+Flying Fungi of Yuggoth,Battle Creek Fifty K,male,Devin,Arenz,3,38.0,Yes
+Flying Fungi of Yuggoth,Seeley Hills Classic,female,Allie,Rykken,1,95.89,Yes
+Flying Fungi of Yuggoth,Seeley Hills Classic,female,Emily,Broderson,2,63.27,Yes
+Flying Fungi of Yuggoth,Seeley Hills Classic,male,Kevin,Johnson,1,95.74,Yes
+Hoigaards/Breadsmith A Team,Battle Creek Fifty K,female,Michelle,Hatch,1,67.65,Yes
+Hoigaards/Breadsmith A Team,Battle Creek Fifty K,female,Kaitsy,Baker,2,50.0,Yes
+Hoigaards/Breadsmith A Team,Seeley Hills Classic,female,Victoria,Ranua,1,69.86,Yes
+Hoigaards/Breadsmith A Team,Seeley Hills Classic,male,John,Rock,1,85.74,Yes
+Hoigaards/Breadsmith A Team,Seeley Hills Classic,male,Paul,Schoening,2,78.16,Yes
+Hoigaards/Breadsmith A Team,Seeley Hills Classic,male,Anders,Sonnesyn,3,20.0,Yes
+Hoigaards/Breadsmith A Team,Seeley Hills Classic,male,Rick,Pike,3,20.0,Yes
+Ski EU Later,Battle Creek Fifty K,female,Julie,Rieth,1,44.29,Yes
+Ski EU Later,Battle Creek Fifty K,female,Sarah,Richter,2,41.18,Yes
+Ski EU Later,Battle Creek Fifty K,female,Molly,Schaus,3,38.24,Yes
+Ski EU Later,Battle Creek Fifty K,male,Ron,Omann,1,73.0,Yes
+Ski EU Later,Battle Creek Fifty K,male,Ryan,Soule,2,71.0,Yes
+Ski EU Later,Battle Creek Fifty K,male,Paul,Earl-Torniainen,3,50.0,Yes
+Ski EU Later,Seeley Hills Classic,female,Julie,Rieth,1,82.97,Yes
+Ski EU Later,Seeley Hills Classic,female,Patty,Carlen,2,20.0,Yes
+Ski EU Later,Seeley Hills Classic,female,Molly,Schaus,2,20.0,Yes
+Ski EU Later,Seeley Hills Classic,female,Sarah,Richter,2,20.0,Yes
+Ski EU Later,Seeley Hills Classic,male,Ron,Omann,1,97.76,Yes
+Ski EU Later,Seeley Hills Classic,male,Joseph,Altendahl,2,20.0,Yes
+Snowbra Kai Academy,Battle Creek Fifty K,male,Dennis,Curran,1,84.0,Yes
+Snowbra Kai Academy,Battle Creek Fifty K,male,Scott,Bjorn Cummings,2,29.0,Yes
+TCSC Frosty Fliers,Battle Creek Fifty K,male,Joe,Harrington,1,93.0,Yes
+TCSC Frosty Fliers,Battle Creek Fifty K,male,Steven,Deckert,2,32.0,Yes
+TCSC Icy Insurgents,Battle Creek Fifty K,female,Katrin,O'Grady,1,97.06,Yes
+TCSC Icy Insurgents,Battle Creek Fifty K,female,Julia,Reich,2,94.12,Yes
+TCSC Icy Insurgents,Battle Creek Fifty K,female,Daisy,Richmond,3,47.06,Yes
+TCSC Icy Insurgents,Battle Creek Fifty K,female,Kathryn,Pintar,4,20.0,No
+TCSC Icy Insurgents,Battle Creek Fifty K,male,Ryan,Rogers,1,99.0,Yes
+TCSC Icy Insurgents,Battle Creek Fifty K,male,Michael,Garlinghouse,2,62.0,Yes
+TCSC Icy Insurgents,Seeley Hills Classic,female,Julia,Lavanger,1,93.15,Yes
+TCSC Icy Insurgents,Seeley Hills Classic,female,Kathryn,Pintar,2,89.04,Yes
+TCSC Icy Insurgents,Seeley Hills Classic,female,Daisy,Richmond,3,20.0,Yes
+TCSC Icy Insurgents,Seeley Hills Classic,male,Chad,Korby,1,96.71,Yes
+Vakava Juniorit,Battle Creek Fifty K,female,Laura,Cattaneo,1,91.18,Yes
+Vakava Juniorit,Battle Creek Fifty K,male,Ian,Wright,1,89.0,Yes
+Vakava Juniorit,Battle Creek Fifty K,male,Josh,Albrecht,2,85.0,Yes
+Vakava Juniorit,Battle Creek Fifty K,male,McEwan,Rodefeld,3,25.0,Yes
+Vakava Juniorit,Battle Creek Fifty K,male,Leif,Hanson,4,24.0,No
+Vakava Juniorit,Seeley Hills Classic,female,Gabby,Vandendries,1,100.0,Yes
+Vakava Juniorit,Seeley Hills Classic,male,Josh,Albrecht,1,99.34,Yes
+Vakava Juniorit,Seeley Hills Classic,male,Leif,Hanson,2,98.68,Yes
+Vakava Seniorit,Battle Creek Fifty K,female,Eva,Reinicke,1,61.76,Yes
+Vakava Seniorit,Battle Creek Fifty K,female,Adrienne,Keller,2,52.94,Yes
+Vakava Seniorit,Battle Creek Fifty K,male,Craig,Cardinal,1,96.0,Yes
+Vakava Seniorit,Battle Creek Fifty K,male,Brock,Lundberg,2,69.0,Yes
+Vakava Seniorit,Battle Creek Fifty K,male,Ben,Mullin,3,29.0,Yes
+Vakava Seniorit,Seeley Hills Classic,female,Eva,Reinicke,1,75.34,Yes
+Vakava Seniorit,Seeley Hills Classic,male,Artie,Huber,1,94.16,Yes
+Vakava Seniorit,Seeley Hills Classic,male,Ben,Mullin,2,92.45,Yes
+Yamageddon,Battle Creek Fifty K,female,Alissa,Johnson,1,55.88,Yes
+Yamageddon,Battle Creek Fifty K,female,Daria,Terenteva,2,44.12,Yes
+Yamageddon,Battle Creek Fifty K,female,Julie,Garretson,3,26.47,Yes
+Yamageddon,Battle Creek Fifty K,male,Andrew,Tilman,1,95.0,Yes
+Yamageddon,Battle Creek Fifty K,male,Louis,Sirota,2,82.0,Yes
+Yamageddon,Battle Creek Fifty K,male,Josh,Doebbert,3,70.0,Yes
+Yamageddon,Seeley Hills Classic,female,Julie,Garretson,1,94.52,Yes
+Yamageddon,Seeley Hills Classic,female,Ana,Zembryki,2,67.12,Yes
+Yamageddon,Seeley Hills Classic,male,Josh,Doebbert,1,88.82,Yes
+Yamageddon,Seeley Hills Classic,male,Andrew,Tilman,2,20.0,Yes
+Yamageddon,Seeley Hills Classic,male,Louis,Sirota,2,20.0,Yes
+Yamageddon,Seeley Hills Classic,male,Erik,Hendrickson,2,20.0,Yes

--- a/orchestrate/s2526/tdf_team_scoring_report.csv
+++ b/orchestrate/s2526/tdf_team_scoring_report.csv
@@ -1,0 +1,79 @@
+team_name,event,gender,first_name,last_name,team_rank,event_points,is_scoring
+Casual Elite,bcfk,male,Will,Nielsen,1,72.0,true
+Casual Elite,bcfk,male,Dave,Niday,2,69.0,true
+Casual Elite,seeley,male,Dave,Niday,1,20.0,true
+Des Moines Lake Nordic Ski Team,seeley,male,Brian,Markes,1,20.0,true
+Des Moines Lake Nordic Ski Team,seeley,male,Adam,Burnett,1,20.0,true
+Finnish Postal Service,bcfk,female,Rebecca,Kolstad,1,58.82352941176471,true
+Finnish Postal Service,bcfk,male,Spencer,Davis,1,90.0,true
+Finnish Postal Service,seeley,female,Molly,Watkins,1,20.0,true
+Finnish Postal Service,seeley,male,Karl,Holub,1,98.02631578947368,true
+Finnish Postal Service,seeley,male,Spencer,Davis,2,95.39473684210526,true
+Flying Fungi of Yuggoth,bcfk,female,Allie,Rykken,1,79.41176470588236,true
+Flying Fungi of Yuggoth,bcfk,male,Kevin,Johnson,1,68.0,true
+Flying Fungi of Yuggoth,bcfk,male,Brett,Arenz,2,57.00000000000001,true
+Flying Fungi of Yuggoth,bcfk,male,Devin,Arenz,3,38.0,true
+Flying Fungi of Yuggoth,seeley,female,Allie,Rykken,1,95.89041095890411,true
+Flying Fungi of Yuggoth,seeley,female,Emily,Broderson,2,63.273972602739725,true
+Flying Fungi of Yuggoth,seeley,male,Kevin,Johnson,1,95.73684210526316,true
+Hoigaards/Breadsmith A Team,bcfk,female,Michelle,Hatch,1,67.64705882352942,true
+Hoigaards/Breadsmith A Team,bcfk,female,Kaitsy,Baker,2,50.0,true
+Hoigaards/Breadsmith A Team,seeley,female,Victoria,Ranua,1,69.86301369863014,true
+Hoigaards/Breadsmith A Team,seeley,male,John,Rock,1,85.73684210526316,true
+Hoigaards/Breadsmith A Team,seeley,male,Paul,Schoening,2,78.15789473684211,true
+Hoigaards/Breadsmith A Team,seeley,male,Anders,Sonnesyn,3,20.0,true
+Hoigaards/Breadsmith A Team,seeley,male,Rick,Pike,3,20.0,true
+Ski EU Later,bcfk,female,Julie,Rieth,1,44.29411764705882,true
+Ski EU Later,bcfk,female,Sarah,Richter,2,41.17647058823529,true
+Ski EU Later,bcfk,female,Molly,Schaus,3,38.23529411764706,true
+Ski EU Later,bcfk,male,Ron,Omann,1,73.0,true
+Ski EU Later,bcfk,male,Ryan,Soule,2,71.0,true
+Ski EU Later,bcfk,male,Paul,Earl-Torniainen,3,50.0,true
+Ski EU Later,seeley,female,Julie,Rieth,1,82.97260273972603,true
+Ski EU Later,seeley,female,Patty,Carlen,2,20.0,true
+Ski EU Later,seeley,female,Molly,Schaus,2,20.0,true
+Ski EU Later,seeley,female,Sarah,Richter,2,20.0,true
+Ski EU Later,seeley,male,Ron,Omann,1,97.76315789473684,true
+Ski EU Later,seeley,male,Joseph,Altendahl,2,20.0,true
+Snowbra Kai Academy,bcfk,male,Dennis,Curran,1,84.0,true
+Snowbra Kai Academy,bcfk,male,Scott,Bjorn Cummings,2,29.000000000000004,true
+TCSC Frosty Fliers,bcfk,male,Joe,Harrington,1,93.0,true
+TCSC Frosty Fliers,bcfk,male,Steven,Deckert,2,31.999999999999996,true
+TCSC Icy Insurgents,bcfk,female,Katrin,O'Grady,1,97.05882352941177,true
+TCSC Icy Insurgents,bcfk,female,Julia,Reich,2,94.11764705882352,true
+TCSC Icy Insurgents,bcfk,female,Daisy,Richmond,3,47.05882352941176,true
+TCSC Icy Insurgents,bcfk,female,Kathryn,Pintar,4,20.0,false
+TCSC Icy Insurgents,bcfk,male,Ryan,Rogers,1,99.0,true
+TCSC Icy Insurgents,bcfk,male,Michael,Garlinghouse,2,62.0,true
+TCSC Icy Insurgents,seeley,female,Julia,Lavanger,1,93.15068493150685,true
+TCSC Icy Insurgents,seeley,female,Kathryn,Pintar,2,89.04109589041096,true
+TCSC Icy Insurgents,seeley,female,Daisy,Richmond,3,20.0,true
+TCSC Icy Insurgents,seeley,male,Chad,Korby,1,96.71052631578947,true
+Vakava Juniorit,bcfk,female,Laura,Cattaneo,1,91.17647058823529,true
+Vakava Juniorit,bcfk,male,Ian,Wright,1,89.0,true
+Vakava Juniorit,bcfk,male,Josh,Albrecht,2,85.0,true
+Vakava Juniorit,bcfk,male,McEwan,Rodefeld,3,25.0,true
+Vakava Juniorit,bcfk,male,Leif,Hanson,4,24.0,false
+Vakava Juniorit,seeley,female,Gabby,Vandendries,1,100.0,true
+Vakava Juniorit,seeley,male,Josh,Albrecht,1,99.3421052631579,true
+Vakava Juniorit,seeley,male,Leif,Hanson,2,98.68421052631578,true
+Vakava Seniorit,bcfk,female,Eva,Reinicke,1,61.76470588235294,true
+Vakava Seniorit,bcfk,female,Adrienne,Keller,2,52.94117647058824,true
+Vakava Seniorit,bcfk,male,Craig,Cardinal,1,96.0,true
+Vakava Seniorit,bcfk,male,Brock,Lundberg,2,69.0,true
+Vakava Seniorit,bcfk,male,Ben,Mullin,3,29.000000000000004,true
+Vakava Seniorit,seeley,female,Eva,Reinicke,1,75.34246575342466,true
+Vakava Seniorit,seeley,male,Artie,Huber,1,94.1578947368421,true
+Vakava Seniorit,seeley,male,Ben,Mullin,2,92.44736842105263,true
+Yamageddon,bcfk,female,Alissa,Johnson,1,55.88235294117647,true
+Yamageddon,bcfk,female,Daria,Terenteva,2,44.11764705882353,true
+Yamageddon,bcfk,female,Julie,Garretson,3,26.470588235294112,true
+Yamageddon,bcfk,male,Andrew,Tilman,1,95.0,true
+Yamageddon,bcfk,male,Louis,Sirota,2,82.0,true
+Yamageddon,bcfk,male,Josh,Doebbert,3,70.0,true
+Yamageddon,seeley,female,Julie,Garretson,1,94.52054794520548,true
+Yamageddon,seeley,female,Ana,Zembryki,2,67.12328767123287,true
+Yamageddon,seeley,male,Josh,Doebbert,1,88.81578947368422,true
+Yamageddon,seeley,male,Andrew,Tilman,2,20.0,true
+Yamageddon,seeley,male,Louis,Sirota,2,20.0,true
+Yamageddon,seeley,male,Erik,Hendrickson,2,20.0,true

--- a/score/__init__.py
+++ b/score/__init__.py
@@ -7,7 +7,7 @@ from orchestrate.s2526 import Event
 from tdfio.const import Gender
 
 @dataclass(frozen=True)
-class EventTeamPointsWithinGenderResult:
+class EventTeamPointsResult:
     team_scores: pl.DataFrame
     report: pl.DataFrame
 
@@ -181,7 +181,7 @@ def _compute_event_team_points_within_gender(
         .agg(pl.col(event_points_column).sum().alias(event_points_column))\
         .select('team_name', event_points_column)
 
-    return EventTeamPointsWithinGenderResult(team_scores=team_scores, report=report_df)
+    return EventTeamPointsResult(team_scores=team_scores, report=report_df)
 
 
 def compute_team_points(
@@ -189,7 +189,7 @@ def compute_team_points(
     male_points: pl.DataFrame,
     female_points: pl.DataFrame,
     events: list[Event],
-):
+) -> EventTeamPointsResult:
     gender_points_by_team = []
     report_dfs: list[pl.DataFrame] = []
 
@@ -227,4 +227,4 @@ def compute_team_points(
         .select(['team_name'] + all_event_columns)\
         .with_columns(pl.sum_horizontal(all_event_columns).alias('total_points'))
 
-    return (final_scores, team_points_report)
+    return EventTeamPointsResult(final_scores, team_points_report)

--- a/score/__init__.py
+++ b/score/__init__.py
@@ -148,7 +148,7 @@ def _compute_event_team_points_within_gender(
 
     ranked = points_joined_membership.with_columns(
         pl.col(event_points_column)
-          .rank(method="dense", descending=True)
+          .rank(method="ordinal", descending=True)
           .over("team_name")
           .alias("team_rank")
     ).with_columns(

--- a/score/__init__.py
+++ b/score/__init__.py
@@ -1,10 +1,15 @@
 import polars as pl
 import heapq
+from dataclasses import dataclass
 
 # TODO this is awkward, have to update the definition each season
 from orchestrate.s2526 import Event
 from tdfio.const import Gender
 
+@dataclass(frozen=True)
+class EventTeamPointsWithinGenderResult:
+    team_scores: pl.DataFrame
+    report: pl.DataFrame
 
 def compute_age_advantage(rr):
     return rr.with_columns(
@@ -128,7 +133,6 @@ def _compute_event_team_points_within_gender(
     membership: pl.DataFrame,
     points: pl.DataFrame,
     e: Event,
-    report_rows: list | None = None,   # NEW
 ) -> pl.DataFrame:
     event_points_column = f'{e.to_string()}_points'
     joinable_points = points.select([event_points_column, 'first_name', 'last_name']).drop_nulls([event_points_column])
@@ -156,19 +160,16 @@ def _compute_event_team_points_within_gender(
         pl.lit(e.get_human_readable_name()).alias("event"),
     )
 
-    if report_rows is not None:
-        report_rows.append(
-            ranked.select([
-                "event",
-                "team_name",
-                "gender",
-                "first_name",
-                "last_name",
-                pl.col(event_points_column).round(2).alias("event_points"),
-                "team_rank",
-                "is_scoring",
-            ])
-        )
+    report_df = ranked.select([
+        "event",
+        "team_name",
+        "gender",
+        "first_name",
+        "last_name",
+        pl.col(event_points_column).round(2).alias("event_points"),
+        "team_rank",
+        "is_scoring",
+    ])
 
     top_3_scorers_by_team = pl.concat([
         x.top_k(3, by=event_points_column)
@@ -177,27 +178,37 @@ def _compute_event_team_points_within_gender(
 
     team_scores = top_3_scorers_by_team\
         .groupby('team_name')\
-        .agg(pl.col(event_points_column).sum().alias(event_points_column))
+        .agg(pl.col(event_points_column).sum().alias(event_points_column))\
+        .select('team_name', event_points_column)
 
-    return team_scores.select('team_name', event_points_column)
+    return EventTeamPointsWithinGenderResult(team_scores=team_scores, report=report_df)
 
 
-def compute_team_points(membership: pl.DataFrame, male_points: pl.DataFrame, female_points: pl.DataFrame, events: list) -> pl.DataFrame:
+def compute_team_points(
+    membership: pl.DataFrame,
+    male_points: pl.DataFrame,
+    female_points: pl.DataFrame,
+    events: list[Event],
+):
     gender_points_by_team = []
-    report_rows: list[pl.DataFrame] = []
+    report_dfs: list[pl.DataFrame] = []
 
     for g in [Gender.female, Gender.male]:
         gender_membership = membership.filter(pl.col('gender') == g.to_string())
         gender_points = male_points if g == Gender.male else female_points
 
-        all_gender_points = _compute_event_team_points_within_gender(gender_membership, gender_points, events[0], report_rows=report_rows)
+        first = _compute_event_team_points_within_gender(gender_membership, gender_points, events[0])
+        report_dfs.append(first.report)
+        all_gender_points = first.team_scores
+
         for e in events[1:]:
-            event_gender_points = _compute_event_team_points_within_gender(gender_membership, gender_points, e, report_rows=report_rows)
-            all_gender_points = all_gender_points.join(event_gender_points, on='team_name', how='outer')
+            res = _compute_event_team_points_within_gender(gender_membership, gender_points, e)
+            report_dfs.append(res.report)
+            all_gender_points = all_gender_points.join(res.team_scores, on="team_name", how="outer")
 
         gender_points_by_team.append(all_gender_points)
 
-    team_points_report = pl.concat(report_rows) if report_rows else pl.DataFrame()
+    team_points_report = pl.concat(report_dfs) if report_dfs else pl.DataFrame()
 
     magic_suffix = '_female'
     gpbt_joined = gender_points_by_team[0]\

--- a/score/__init__.py
+++ b/score/__init__.py
@@ -148,9 +148,12 @@ def _compute_event_team_points_within_gender(
           .over("team_name")
           .alias("team_rank")
     ).with_columns(
-        (pl.col("team_rank") <= 3).alias("is_scoring")
+        pl.when(pl.col("team_rank") <= 3)
+          .then(pl.lit("Yes"))
+          .otherwise(pl.lit("No"))
+          .alias("is_scoring")
     ).with_columns(
-        pl.lit(e.to_string()).alias("event"),
+        pl.lit(e.get_human_readable_name()).alias("event"),
     )
 
     if report_rows is not None:
@@ -161,7 +164,7 @@ def _compute_event_team_points_within_gender(
                 "gender",
                 "first_name",
                 "last_name",
-                pl.col(event_points_column).alias("event_points"),
+                pl.col(event_points_column).round(2).alias("event_points"),
                 "team_rank",
                 "is_scoring",
             ])


### PR DESCRIPTION
One additional output from a season orchestration that emits a team scoring summary.

My thought would be to add this to the same output Drew already posts.  This allows anyone (up to and including the team captain to look at the scoring summary and find where something has gone awry.